### PR TITLE
Add method to return data for some years only

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,28 @@ async function fetchDataForAllYears(username) {
   });
 }
 
+async function fetchDataForSomeYears(username, exceptionList) {
+  const allYears = await fetchYears(username);
+  const years = allYears.filter(year => exceptionList.indexOf(year.text) === -1);
+  return Promise.all(
+    years.map(year => fetchDataForYear(year.href, year.text))
+  ).then(resp => {
+    return {
+      years: resp.map(year => {
+        const { contributions, ...rest } = year;
+        return rest;
+      }),
+      contributions: resp
+        .reduce((list, curr) => [...list, ...curr.contributions], [])
+        .sort((a, b) => {
+          if (a.date < b.date) return 1;
+          else if (a.date > b.date) return -1;
+          return 0;
+        })
+    };
+  });
+}
+
 async function getMediaUrl(base64data) {
   try {
     const buff = dataUriToBuffer(base64data);


### PR DESCRIPTION
Currently the API only gives the option of getting the information for all the years we've been registered.

When checking the chart for my contributions I noticed that I've had this account for a long time before really getting active, which causes the chart to be filled with 'blank' years.

I though about adding an option for an user to exclude certain years so I created this PR. Obviously, this would also require a change in the frontend project, but I haven't looked at it yet.

Let me know if you think this could be a valid thing, even if some changes are needed.